### PR TITLE
Refactor imports in __init__.py to use relative imports 

### DIFF
--- a/opcuaAutomation/__init__.py
+++ b/opcuaAutomation/__init__.py
@@ -1,3 +1,4 @@
-from opcuaAutomation import client_OPC_UA
-from opcuaAutomation import resultsObjects
-from opcuaAutomation import uaDataType
+
+from .client_OPC_UA import client_OPC_UA
+from .resultsObjects import OpcuaConnectResult, OpcuaReadResult, OpcuaWriteResult
+from .uaDataType import getVariantType


### PR DESCRIPTION
Refactored the imports in __init__.py to use relative imports. Key classes (client_OPC_UA, OpcuaConnectResult, OpcuaReadResult, OpcuaWriteResult) and functions (getVariantType) are now directly accessible from the package.